### PR TITLE
feat: Add automatic tab grouping by domain

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,7 @@
   "description": "🧹 Modern tab management with smart cleanup and organization features",
   "permissions": [
     "tabs",
+    "tabGroups",
     "storage",
     "alarms",
     "notifications"

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -255,6 +255,18 @@ button.primary:active {
   transform: translateY(0);
 }
 
+button.group-btn {
+  background: linear-gradient(135deg, var(--success-color), #2f855a);
+  color: white;
+  font-weight: 600;
+}
+
+button.group-btn:hover {
+  background: linear-gradient(135deg, var(--success-hover), #276749);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg);
+}
+
 .info {
   background: var(--surface);
   border-radius: var(--radius-lg);
@@ -288,8 +300,12 @@ button.primary:active {
   margin-right: 8px;
 }
 
-.info p:last-child::before {
+.info p:nth-child(2)::before {
   content: '⏱️';
+}
+
+.info p:last-child::before {
+  content: '📁';
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -32,6 +32,8 @@
     <div class="buttons">
       <button id="closeInactiveTabs" class="primary">🚀 Close Inactive Tabs</button>
       <button id="previewInactiveTabs">👀 Preview Inactive Tabs</button>
+      <button id="groupTabsByDomain" class="group-btn">📁 Group by Domain</button>
+      <button id="ungroupAllTabs" class="group-btn">📂 Ungroup All</button>
       <button id="closeAllTabs">🗑️ Close All Tabs</button>
       <button id="closeDuplicates">🔄 Close Duplicates</button>
     </div>
@@ -39,6 +41,7 @@
     <div class="info">
       <p id="tabCount">Loading...</p>
       <p id="inactiveCount">Inactive tabs: 0</p>
+      <p id="groupCount">Tab groups: 0</p>
     </div>
   </div>
   <script src="popup.js"></script>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -3,10 +3,13 @@ document.addEventListener('DOMContentLoaded', function() {
   const closeDuplicatesBtn = document.getElementById('closeDuplicates');
   const closeInactiveTabsBtn = document.getElementById('closeInactiveTabs');
   const previewInactiveTabsBtn = document.getElementById('previewInactiveTabs');
+  const groupTabsByDomainBtn = document.getElementById('groupTabsByDomain');
+  const ungroupAllTabsBtn = document.getElementById('ungroupAllTabs');
   const inactiveTimeSelect = document.getElementById('inactiveTime');
   const autoCleanupCheckbox = document.getElementById('autoCleanup');
   const tabCountElement = document.getElementById('tabCount');
   const inactiveCountElement = document.getElementById('inactiveCount');
+  const groupCountElement = document.getElementById('groupCount');
 
   function loadSettings() {
     chrome.storage.sync.get(['inactiveTime', 'autoCleanup'], function(result) {
@@ -59,6 +62,7 @@ document.addEventListener('DOMContentLoaded', function() {
       if (chrome.runtime.lastError) {
         tabCountElement.textContent = 'Total tabs: Error';
         inactiveCountElement.textContent = 'Inactive tabs: Error';
+        groupCountElement.textContent = 'Tab groups: Error';
         return;
       }
       
@@ -68,6 +72,14 @@ document.addEventListener('DOMContentLoaded', function() {
       getInactiveTabs(inactiveMinutes, function(inactiveTabs) {
         inactiveCountElement.textContent = `Inactive tabs: ${inactiveTabs.length}`;
       });
+
+      chrome.tabGroups.query({}, function(groups) {
+        if (chrome.runtime.lastError) {
+          groupCountElement.textContent = 'Tab groups: Error';
+          return;
+        }
+        groupCountElement.textContent = `Tab groups: ${groups.length}`;
+      });
     });
   }
 
@@ -76,6 +88,108 @@ document.addEventListener('DOMContentLoaded', function() {
     const hours = Math.floor(minutes / 60);
     const mins = minutes % 60;
     return mins === 0 ? `${hours}h` : `${hours}h ${mins}m`;
+  }
+
+  function getDomainFromUrl(url) {
+    try {
+      const domain = new URL(url).hostname;
+      return domain.replace(/^www\./, '');
+    } catch {
+      return 'other';
+    }
+  }
+
+  function getGroupColors() {
+    return ['blue', 'red', 'yellow', 'green', 'pink', 'purple', 'cyan', 'orange'];
+  }
+
+  function groupTabsByDomain() {
+    chrome.tabs.query({}, function(tabs) {
+      if (chrome.runtime.lastError) {
+        alert('Error accessing tabs.');
+        return;
+      }
+
+      const domainGroups = {};
+      const pinnedTabs = [];
+      
+      tabs.forEach(tab => {
+        if (tab.pinned) {
+          pinnedTabs.push(tab);
+          return;
+        }
+        
+        const domain = getDomainFromUrl(tab.url);
+        if (!domainGroups[domain]) {
+          domainGroups[domain] = [];
+        }
+        domainGroups[domain].push(tab);
+      });
+
+      const colors = getGroupColors();
+      let colorIndex = 0;
+      let groupsCreated = 0;
+
+      Object.entries(domainGroups).forEach(([domain, domainTabs]) => {
+        if (domainTabs.length < 2) return;
+
+        const tabIds = domainTabs.map(tab => tab.id);
+        const groupColor = colors[colorIndex % colors.length];
+        
+        chrome.tabs.group({ tabIds: tabIds }, function(groupId) {
+          if (chrome.runtime.lastError) {
+            return;
+          }
+          
+          chrome.tabGroups.update(groupId, {
+            title: domain,
+            color: groupColor
+          }, function() {
+            if (!chrome.runtime.lastError) {
+              groupsCreated++;
+            }
+          });
+        });
+        
+        colorIndex++;
+      });
+
+      setTimeout(() => {
+        if (groupsCreated > 0) {
+          alert(`Created ${groupsCreated} tab groups by domain.`);
+          updateTabCounts();
+        } else {
+          alert('No groups created. Need at least 2 tabs per domain to create groups.');
+        }
+      }, 500);
+    });
+  }
+
+  function ungroupAllTabs() {
+    chrome.tabGroups.query({}, function(groups) {
+      if (chrome.runtime.lastError) {
+        alert('Error accessing tab groups.');
+        return;
+      }
+
+      if (groups.length === 0) {
+        alert('No tab groups found.');
+        return;
+      }
+
+      if (confirm(`Ungroup all ${groups.length} tab groups?`)) {
+        groups.forEach(group => {
+          chrome.tabs.ungroup(group.id, function() {
+            // Ignore errors - some groups might already be removed
+          });
+        });
+        
+        setTimeout(() => {
+          alert('All tab groups have been ungrouped.');
+          updateTabCounts();
+        }, 300);
+      }
+    });
   }
 
   closeInactiveTabsBtn.addEventListener('click', function() {
@@ -173,6 +287,9 @@ document.addEventListener('DOMContentLoaded', function() {
   });
 
   autoCleanupCheckbox.addEventListener('change', saveSettings);
+
+  groupTabsByDomainBtn.addEventListener('click', groupTabsByDomain);
+  ungroupAllTabsBtn.addEventListener('click', ungroupAllTabs);
 
   loadSettings();
   updateTabCounts();


### PR DESCRIPTION
Implements automatic tab grouping functionality requested in issue #5.

## Features
- Domain-based tab grouping with color coding
- "Group by Domain" and "Ungroup All" UI controls
- Visual indicators and group count display
- Smart grouping logic (only groups domains with 2+ tabs)
- Preserves pinned tabs

## Technical Details
- Added tabGroups permission to manifest.json
- Implemented grouping functions in popup.js
- Added styled UI controls in popup.html/css
- Uses 8 rotating colors for visual distinction

Closes #5

🤖 Generated with [Claude Code](https://claude.ai/code)